### PR TITLE
Add VS.LSP.CompletionItem

### DIFF
--- a/autoload/vital/__vital__/VS/LSP/CompletionItem.vim
+++ b/autoload/vital/__vital__/VS/LSP/CompletionItem.vim
@@ -106,7 +106,7 @@ function! s:_get_replacement(suggest_position, current_position, request_positio
       \   'is_snippet': l:is_snippet,
       \ }
     endif
-  elseif l:is_snippet
+  else
     let l:inserted = strcharpart(l:line, a:suggest_position.character, a:current_position.character - a:suggest_position.character)
     let l:new_text = get(a:completion_item, 'insertText', a:completion_item.label)
     if s:_trim_tabstop(l:new_text) !=# l:inserted
@@ -114,7 +114,7 @@ function! s:_get_replacement(suggest_position, current_position, request_positio
       \   'overflow_before': a:request_position.character - a:suggest_position.character,
       \   'overflow_after': 0,
       \   'new_text': l:new_text,
-      \   'is_snippet': v:true,
+      \   'is_snippet': l:is_snippet,
       \ }
     endif
   endif

--- a/autoload/vital/__vital__/VS/LSP/CompletionItem.vim
+++ b/autoload/vital/__vital__/VS/LSP/CompletionItem.vim
@@ -1,0 +1,130 @@
+function! s:_vital_loaded(V) abort
+  let s:Position = a:V.import('VS.LSP.Position')
+  let s:TextEdit = a:V.import('VS.LSP.TextEdit')
+  let s:Text = a:V.import('VS.LSP.Text')
+endfunction
+
+"
+" confirm
+"
+" @param {v:completed_item} completed_item
+" @param {LSP.Position} request_position
+" @param {LSP.CompletionItem} completion_item
+" @param {(args: { body: string; }) => void} snippet
+"
+" # Pre condition
+" This method will work only accepting item via `<C-y>` and the cursor position must be the end of completed word.
+"
+" # The positoins
+"
+"   0. The example case
+"
+"     call getbufl|<C-x><C-o><C-n><C-y>   ->   call getbufline|
+"
+"   1. current_position
+"
+"     call getbufline|
+"
+"   2. request_position
+"
+"     call getbufl|ine
+"
+"   3. suggest_position
+"
+"     call |getbufline
+"
+"
+function! s:confirm(completed_item, request_position, completion_item, ...) abort
+  let l:Snippet = get(a:000, 0, v:null)
+  let l:current_position = s:Position.cursor()
+  let l:suggest_position = { 'line': l:current_position.line, 'character': l:current_position.character - strchars(a:completed_item.word) }
+
+  " 1. Restore state of the timing when `textDocument/completion` was sent if expansion is needed
+  let l:replacement = s:_get_replacement(l:suggest_position, l:current_position, a:request_position, a:completion_item)
+  if !empty(l:replacement)
+    call s:TextEdit.apply('%', [{
+    \   'range': { 'start': a:request_position, 'end': l:current_position },
+    \   'newText': ''
+    \ }])
+  endif
+
+  " 2. Apply additionalTextEdits
+  if type(get(a:completion_item, 'additionalTextEdits', v:null)) == type([])
+    call s:TextEdit.apply('%', a:completion_item.additionalTextEdits)
+  endif
+
+  " 3. Apply expansion
+  if !empty(l:replacement)
+    let l:current_position = s:Position.cursor() " Update current_position to after additionalTextEdits.
+    let l:range = {
+    \   'start': extend({
+    \     'character': l:current_position.character - l:replacement.overflow_before,
+    \   }, l:current_position, 'keep'),
+    \   'end': extend({
+    \     'character': l:current_position.character + l:replacement.overflow_after,
+    \   }, l:current_position, 'keep')
+    \ }
+
+    " Snippet.
+    if l:replacement.is_snippet && !empty(l:Snippet)
+      call s:TextEdit.apply('%', [{ 'range': l:range, 'newText': '' }])
+      call l:Snippet({ 'body': l:replacement.new_text })
+
+    " TextEdit.
+    else
+      call s:TextEdit.apply('%', [{ 'range': l:range, 'newText': l:replacement.new_text }])
+
+      " Move cursor position to end of new_text like as snippet.
+      let l:lines = s:Text.split_by_eol(l:replacement.new_text)
+      let l:cursor = copy(l:range.start)
+      let l:cursor.line += len(l:lines) - 1
+      let l:cursor.character = len(l:lines) == 1 ? l:cursor.character + strchars(l:lines[-1]) : strchars(l:lines[-1])
+      call cursor(s:Position.lsp_to_vim('%', l:cursor))
+    endif
+  endif
+endfunction
+
+"
+" _get_replacement
+"
+function! s:_get_replacement(suggest_position, current_position, request_position, completion_item) abort
+  let l:line = getline('.')
+  let l:is_snippet = get(a:completion_item, 'insertTextFormat', 1) == 2
+  if type(get(a:completion_item, 'textEdit', v:null)) == type({})
+    let l:inserted_text = strcharpart(l:line, a:request_position.character, a:current_position.character - a:request_position.character)
+    let l:overflow_before = a:request_position.character - a:completion_item.textEdit.range.start.character
+    let l:overflow_after = a:completion_item.textEdit.range.end.character - a:request_position.character
+    let l:inserted = ''
+    \   . strcharpart(l:line, a:request_position.character - l:overflow_before, l:overflow_before)
+    \   . strcharpart(l:line, a:request_position.character, strchars(l:inserted_text) + l:overflow_after)
+    let l:new_text = a:completion_item.textEdit.newText
+    if s:_trim_tabstop(l:new_text) !=# l:inserted
+      return {
+      \   'overflow_before': l:overflow_before,
+      \   'overflow_after': l:overflow_after,
+      \   'new_text': l:new_text,
+      \   'is_snippet': l:is_snippet,
+      \ }
+    endif
+  elseif l:is_snippet
+    let l:inserted = strcharpart(l:line, a:suggest_position.character, a:current_position.character - a:suggest_position.character)
+    let l:new_text = get(a:completion_item, 'insertText', a:completion_item.label)
+    if s:_trim_tabstop(l:new_text) !=# l:inserted
+      return {
+      \   'overflow_before': a:request_position.character - a:suggest_position.character,
+      \   'overflow_after': 0,
+      \   'new_text': l:new_text,
+      \   'is_snippet': v:true,
+      \ }
+    endif
+  endif
+  return {}
+endfunction
+
+"
+" _trim_tabstop
+"
+function! s:_trim_tabstop(text) abort
+  return substitute(a:text, '\%(\$0\|\${0}\)$', '', 'g')
+endfunction
+

--- a/autoload/vital/__vital__/VS/LSP/CompletionItem.vimspec
+++ b/autoload/vital/__vital__/VS/LSP/CompletionItem.vimspec
@@ -21,61 +21,88 @@ Describe vital#__vital__#VS#LSP#CompletionItem
 
       Describe snippet
         It should not expand
-          let [l:completed_item, l:request_position] = s:prepare(['call ^getbufl!ine#'])
+          let [l:suggest_position, l:request_position] = s:prepare(['call ^getbufl!ine#'])
           let l:changedtick = b:changedtick
           let l:buflines = getline('^', '$')
-          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
-          \   'insertTextFormat': 2,
-          \   'textEdit': s:text_edit([1, 6], [1, 13], 'getbufline$0')
-          \ }, { args -> s:snippet(args.body) })
-          call s:expect(l:buflines).to_equal(getline('^', '$'))
+          call s:CompletionItem.confirm({
+          \   'suggest_position': l:suggest_position,
+          \   'request_position': l:request_position,
+          \   'completion_item': {
+          \     'insertTextFormat': 2,
+          \     'textEdit': s:text_edit([1, 6], [1, 13], 'getbufline$0')
+          \   },
+          \   'expand_snippet': { args -> s:snippet(args.body) }
+          \ })
           call s:expect(l:changedtick).to_equal(b:changedtick)
+          call s:expect(l:buflines).to_equal(getline('^', '$'))
         End
 
         It should expand as insert
-          let [l:completed_item, l:request_position] = s:prepare(['call ^getbuf!line#'])
-          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
-          \   'insertTextFormat': 2,
-          \   'textEdit': s:text_edit([1, 12], [1, 12], 'info$0')
-          \ }, { args -> s:snippet(args.body) })
+          let [l:suggest_position, l:request_position] = s:prepare(['call ^getbuf!line#'])
+          call s:CompletionItem.confirm({
+          \   'suggest_position': l:suggest_position,
+          \   'request_position': l:request_position,
+          \   'completion_item': {
+          \     'insertTextFormat': 2,
+          \     'textEdit': s:text_edit([1, 12], [1, 12], 'info$0')
+          \   },
+          \   'expand_snippet': { args -> s:snippet(args.body) }
+          \ })
           call s:expect(getline('^', '$')).to_equal(['call getbufinfo'])
         End
 
         It should expand as replace
-          let [l:completed_item, l:request_position] = s:prepare(['call ^getbuf!#line'])
-          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
-          \   'insertTextFormat': 2,
-          \   'textEdit': s:text_edit([1, 6], [1, 16], 'getbufinfo$0')
-          \ }, { args -> s:snippet(args.body) })
+          let [l:suggest_position, l:request_position] = s:prepare(['call ^getbuf!#line'])
+          call s:CompletionItem.confirm({
+          \   'suggest_position': l:suggest_position,
+          \   'request_position': l:request_position,
+          \   'completion_item': {
+          \     'insertTextFormat': 2,
+          \     'textEdit': s:text_edit([1, 6], [1, 16], 'getbufinfo$0')
+          \   },
+          \   'expand_snippet': { args -> s:snippet(args.body) }
+          \ })
           call s:expect(getline('^', '$')).to_equal(['call getbufinfo'])
         End
       End
 
       Describe plain
         It should not expand
-          let [l:completed_item, l:request_position] = s:prepare(['call ^getbufl!ine#'])
+          let [l:suggest_position, l:request_position] = s:prepare(['call ^getbufl!ine#'])
           let l:changedtick = b:changedtick
           let l:buflines = getline('^', '$')
-          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
-          \   'textEdit': s:text_edit([1, 6], [1, 13], 'getbufline')
-          \ }, { args -> s:snippet(args.body) })
-          call s:expect(l:buflines).to_equal(getline('^', '$'))
+          call s:CompletionItem.confirm({
+          \   'suggest_position': l:suggest_position,
+          \   'request_position': l:request_position,
+          \   'completion_item': {
+          \     'textEdit': s:text_edit([1, 6], [1, 13], 'getbufline')
+          \   },
+          \ })
           call s:expect(l:changedtick).to_equal(b:changedtick)
+          call s:expect(l:buflines).to_equal(getline('^', '$'))
         End
 
         It should expand as insert
-          let [l:completed_item, l:request_position] = s:prepare(['call ^getbuf!line#'])
-          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
-          \   'textEdit': s:text_edit([1, 12], [1, 12], 'info')
-          \ }, { args -> s:snippet(args.body) })
+          let [l:suggest_position, l:request_position] = s:prepare(['call ^getbuf!line#'])
+          call s:CompletionItem.confirm({
+          \   'suggest_position': l:suggest_position,
+          \   'request_position': l:request_position,
+          \   'completion_item': {
+          \     'textEdit': s:text_edit([1, 12], [1, 12], 'info')
+          \   },
+          \ })
           call s:expect(getline('^', '$')).to_equal(['call getbufinfo'])
         End
 
         It should expand as replace
-          let [l:completed_item, l:request_position] = s:prepare(['call ^getbuf!#line'])
-          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
-          \   'textEdit': s:text_edit([1, 6], [1, 16], 'getbufinfo')
-          \ }, { args -> s:snippet(args.body) })
+          let [l:suggest_position, l:request_position] = s:prepare(['call ^getbuf!#line'])
+          call s:CompletionItem.confirm({
+          \   'suggest_position': l:suggest_position,
+          \   'request_position': l:request_position,
+          \   'completion_item': {
+          \     'textEdit': s:text_edit([1, 6], [1, 16], 'getbufinfo')
+          \   },
+          \ })
           call s:expect(getline('^', '$')).to_equal(['call getbufinfo'])
         End
       End
@@ -86,48 +113,66 @@ Describe vital#__vital__#VS#LSP#CompletionItem
 
       Describe snippet
         It should not expand
-          let [l:completed_item, l:request_position] = s:prepare(['call ^getbufl!ine#'])
+          let [l:suggest_position, l:request_position] = s:prepare(['call ^getbufl!ine#'])
           let l:changedtick = b:changedtick
           let l:buflines = getline('^', '$')
-          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
-          \   'label': '',
-          \   'insertTextFormat': 2,
-          \   'insertText': 'getbufline$0'
-          \ }, { args -> s:snippet(args.body) })
-          call s:expect(l:buflines).to_equal(getline('^', '$'))
+          call s:CompletionItem.confirm({
+          \   'suggest_position': l:suggest_position,
+          \   'request_position': l:request_position,
+          \   'completion_item': {
+          \     'label': '',
+          \     'insertTextFormat': 2,
+          \     'insertText': 'getbufline$0'
+          \   },
+          \   'expand_snippet': { args -> s:snippet(args.body) }
+          \ })
           call s:expect(l:changedtick).to_equal(b:changedtick)
+          call s:expect(l:buflines).to_equal(getline('^', '$'))
         End
 
         It should expand
-          let [l:completed_item, l:request_position] = s:prepare(['call ^getbuf!line#'])
-          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
-          \   'label': '',
-          \   'insertTextFormat': 2,
-          \   'insertText': 'getbufinfo$0'
-          \ }, { args -> s:snippet(args.body) })
+          let [l:suggest_position, l:request_position] = s:prepare(['call ^getbuf!line#'])
+          call s:CompletionItem.confirm({
+          \   'suggest_position': l:suggest_position,
+          \   'request_position': l:request_position,
+          \   'completion_item': {
+          \     'label': '',
+          \     'insertTextFormat': 2,
+          \     'insertText': 'getbufinfo$0'
+          \   },
+          \   'expand_snippet': { args -> s:snippet(args.body) }
+          \ })
           call s:expect(getline('^', '$')).to_equal(['call getbufinfo'])
         End
       End
 
       Describe plain
         It should not expand
-          let [l:completed_item, l:request_position] = s:prepare(['call ^getbufl!ine#'])
+          let [l:suggest_position, l:request_position] = s:prepare(['call ^getbufl!ine#'])
           let l:changedtick = b:changedtick
           let l:buflines = getline('^', '$')
-          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
-          \   'label': '',
-          \   'insertText': 'getbufline'
-          \ }, { args -> s:snippet(args.body) })
+          call s:CompletionItem.confirm({
+          \   'suggest_position': l:suggest_position,
+          \   'request_position': l:request_position,
+          \   'completion_item': {
+          \     'label': '',
+          \     'insertText': 'getbufline'
+          \   },
+          \ })
           call s:expect(l:buflines).to_equal(getline('^', '$'))
           call s:expect(l:changedtick).to_equal(b:changedtick)
         End
 
         It should expand
-          let [l:completed_item, l:request_position] = s:prepare(['call ^getbuf!line#'])
-          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
-          \   'label': '',
-          \   'insertText': 'getbufinfo'
-          \ }, { args -> s:snippet(args.body) })
+          let [l:suggest_position, l:request_position] = s:prepare(['call ^getbuf!line#'])
+          call s:CompletionItem.confirm({
+          \   'suggest_position': l:suggest_position,
+          \   'request_position': l:request_position,
+          \   'completion_item': {
+          \     'label': '',
+          \     'insertText': 'getbufinfo'
+          \   },
+          \ })
           call s:expect(getline('^', '$')).to_equal(['call getbufinfo'])
         End
       End
@@ -137,18 +182,23 @@ Describe vital#__vital__#VS#LSP#CompletionItem
     Describe realworld
 
       It rust-analyzer 1
-        let [l:completed_item, l:request_position] = s:prepare([
+        let [l:suggest_position, l:request_position] = s:prepare([
         \   'fn main() {',
         \   '    "aiueo"',
         \   '        .^box!#',
         \   '}',
         \ ])
-        call s:CompletionItem.confirm(l:completed_item, l:request_position, {
-        \   'label': 'box',
-        \   'insertTextFormat': 2,
-        \   'additionalTextEdits': [{'range': {'end': {'character': 9, 'line': 2}, 'start': {'character': 4, 'line': 1}}, 'newText': ''}],
-        \   'textEdit': {'range': {'end': {'character': 12, 'line': 2}, 'start': {'character': 9, 'line': 2}}, 'newText': 'Box::new("aiueo")'},
-        \ }, { args -> s:snippet(args.body) })
+        call s:CompletionItem.confirm({
+        \   'suggest_position': l:suggest_position,
+        \   'request_position': l:request_position,
+        \   'completion_item': {
+        \     'label': 'box',
+        \     'insertTextFormat': 2,
+        \     'additionalTextEdits': [{'range': {'end': {'character': 9, 'line': 2}, 'start': {'character': 4, 'line': 1}}, 'newText': ''}],
+        \     'textEdit': {'range': {'end': {'character': 12, 'line': 2}, 'start': {'character': 9, 'line': 2}}, 'newText': 'Box::new("aiueo")'},
+        \   },
+        \   'expand_snippet': { args -> s:snippet(args.body) }
+        \ })
         call s:expect(getline('^', '$')).to_equal([
         \   'fn main() {',
         \   '    Box::new("aiueo")',
@@ -157,17 +207,21 @@ Describe vital#__vital__#VS#LSP#CompletionItem
       End
 
       It rust-analyzer 2
-        let [l:completed_item, l:request_position] = s:prepare([
+        let [l:suggest_position, l:request_position] = s:prepare([
         \   'fn main() {',
         \   '    ^PathBuf!#',
         \   '}',
         \ ])
-        call s:CompletionItem.confirm(l:completed_item, l:request_position, {
-        \   'label': 'std::path::PathBuf',
-        \   'textEdit': {'range': {'end': {'character': 11, 'line': 1}, 'start': {'character': 4, 'line': 1}}, 'newText': 'PathBuf'},
-        \   'additionalTextEdits': [{'range': {'end': {'character': 0, 'line': 0}, 'start': {'character': 0, 'line': 0}}, 'newText': 'use std::path::PathBuf;'}, {'range': {'end': {'character': 0, 'line': 0}, 'start': {'character': 0, 'line': 0}}, 'newText': "\n\n"}],
-        \   'insertTextFormat': 1,
-        \ }, { args -> s:snippet(args.body) })
+        call s:CompletionItem.confirm({
+        \   'suggest_position': l:suggest_position,
+        \   'request_position': l:request_position,
+        \   'completion_item': {
+        \     'label': 'std::path::PathBuf',
+        \     'textEdit': {'range': {'end': {'character': 11, 'line': 1}, 'start': {'character': 4, 'line': 1}}, 'newText': 'PathBuf'},
+        \     'additionalTextEdits': [{'range': {'end': {'character': 0, 'line': 0}, 'start': {'character': 0, 'line': 0}}, 'newText': 'use std::path::PathBuf;'}, {'range': {'end': {'character': 0, 'line': 0}, 'start': {'character': 0, 'line': 0}}, 'newText': "\n\n"}],
+        \     'insertTextFormat': 1,
+        \   },
+        \ })
         call s:expect(getline('^', '$')).to_equal([
         \   'use std::path::PathBuf;',
         \   '',
@@ -178,17 +232,21 @@ Describe vital#__vital__#VS#LSP#CompletionItem
       End
 
       It vscode-html-language-server 1
-        let [l:completed_item, l:request_position] = s:prepare([
+        let [l:suggest_position, l:request_position] = s:prepare([
         \   '<html>',
         \   '  <div>',
         \   '    </^!#>',
         \   '</html>',
         \ ])
-        call s:CompletionItem.confirm(l:completed_item, l:request_position, {
-        \   'label': '/div',
-        \   'textEdit': {'range': {'end': {'character': 6, 'line': 2}, 'start': {'character': 0, 'line': 2}}, 'newText': '  </div'},
-        \   'insertTextFormat': 1
-        \ }, { args -> s:snippet(args.body) })
+        call s:CompletionItem.confirm({
+        \   'suggest_position': l:suggest_position,
+        \   'request_position': l:request_position,
+        \   'completion_item': {
+        \     'label': '/div',
+        \     'textEdit': {'range': {'end': {'character': 6, 'line': 2}, 'start': {'character': 0, 'line': 2}}, 'newText': '  </div'},
+        \     'insertTextFormat': 1
+        \   },
+        \ })
         call s:expect(getline('^', '$')).to_equal([
         \   '<html>',
         \   '  <div>',
@@ -210,12 +268,13 @@ function! s:prepare(lines) abort
     let l:line = a:lines[l:i]
     if stridx(l:line, '^') >= 0 && stridx(l:line, '!') >= 0 && stridx(l:line, '#') >= 0
       let l:parts = split(l:line, '\^\|!\|#')
+      let l:suggest_position = { 'line': l:lnum - 1, 'character': strchars(join(l:parts[0 : 0], '')) }
       let l:request_position = { 'line': l:lnum - 1, 'character': strchars(join(l:parts[0 : 1], '')) }
       let l:current_position = { 'line': l:lnum - 1, 'character': strchars(join(l:parts[0 : 2], '')) }
       let l:word = join(l:parts[1 : 2], '')
       call setline(l:i + 1, join(l:parts, ''))
       call cursor(s:Position.lsp_to_vim('%', l:current_position))
-      return [{ 'word': l:word }, l:request_position]
+      return [l:suggest_position, l:request_position]
     endif
   endfor
   throw 'the target line can''t detected'

--- a/autoload/vital/__vital__/VS/LSP/CompletionItem.vimspec
+++ b/autoload/vital/__vital__/VS/LSP/CompletionItem.vimspec
@@ -1,0 +1,249 @@
+let s:expect = themis#helper('expect')
+let s:Text = vital#vital#import('VS.LSP.Text')
+let s:Position = vital#vital#import('VS.LSP.Position')
+let s:TextEdit = vital#vital#import('VS.LSP.TextEdit')
+let s:CompletionItem = vital#vital#import('VS.LSP.CompletionItem')
+
+Describe vital#__vital__#VS#LSP#CompletionItem
+
+  Before each
+    enew!
+    setlocal virtualedit=onemore
+  End
+
+  After each
+    bdelete!
+  End
+
+  Describe #confirm
+
+    Describe TextEdit
+
+      Describe snippet
+        It should not expand
+          let [l:completed_item, l:request_position] = s:prepare(['call ^getbufl!ine#'])
+          let l:changedtick = b:changedtick
+          let l:buflines = getline('^', '$')
+          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
+          \   'insertTextFormat': 2,
+          \   'textEdit': s:text_edit([1, 6], [1, 13], 'getbufline$0')
+          \ }, { args -> s:snippet(args.body) })
+          call s:expect(l:buflines).to_equal(getline('^', '$'))
+          call s:expect(l:changedtick).to_equal(b:changedtick)
+        End
+
+        It should expand as insert
+          let [l:completed_item, l:request_position] = s:prepare(['call ^getbuf!line#'])
+          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
+          \   'insertTextFormat': 2,
+          \   'textEdit': s:text_edit([1, 12], [1, 12], 'info$0')
+          \ }, { args -> s:snippet(args.body) })
+          call s:expect(getline('^', '$')).to_equal(['call getbufinfo'])
+        End
+
+        It should expand as replace
+          let [l:completed_item, l:request_position] = s:prepare(['call ^getbuf!#line'])
+          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
+          \   'insertTextFormat': 2,
+          \   'textEdit': s:text_edit([1, 6], [1, 16], 'getbufinfo$0')
+          \ }, { args -> s:snippet(args.body) })
+          call s:expect(getline('^', '$')).to_equal(['call getbufinfo'])
+        End
+      End
+
+      Describe plain
+        It should not expand
+          let [l:completed_item, l:request_position] = s:prepare(['call ^getbufl!ine#'])
+          let l:changedtick = b:changedtick
+          let l:buflines = getline('^', '$')
+          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
+          \   'textEdit': s:text_edit([1, 6], [1, 13], 'getbufline')
+          \ }, { args -> s:snippet(args.body) })
+          call s:expect(l:buflines).to_equal(getline('^', '$'))
+          call s:expect(l:changedtick).to_equal(b:changedtick)
+        End
+
+        It should expand as insert
+          let [l:completed_item, l:request_position] = s:prepare(['call ^getbuf!line#'])
+          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
+          \   'textEdit': s:text_edit([1, 12], [1, 12], 'info')
+          \ }, { args -> s:snippet(args.body) })
+          call s:expect(getline('^', '$')).to_equal(['call getbufinfo'])
+        End
+
+        It should expand as replace
+          let [l:completed_item, l:request_position] = s:prepare(['call ^getbuf!#line'])
+          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
+          \   'textEdit': s:text_edit([1, 6], [1, 16], 'getbufinfo')
+          \ }, { args -> s:snippet(args.body) })
+          call s:expect(getline('^', '$')).to_equal(['call getbufinfo'])
+        End
+      End
+
+    End
+
+    Describe insertText
+
+      Describe snippet
+        It should not expand
+          let [l:completed_item, l:request_position] = s:prepare(['call ^getbufl!ine#'])
+          let l:changedtick = b:changedtick
+          let l:buflines = getline('^', '$')
+          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
+          \   'label': '',
+          \   'insertTextFormat': 2,
+          \   'insertText': 'getbufline$0'
+          \ }, { args -> s:snippet(args.body) })
+          call s:expect(l:buflines).to_equal(getline('^', '$'))
+          call s:expect(l:changedtick).to_equal(b:changedtick)
+        End
+
+        It should expand
+          let [l:completed_item, l:request_position] = s:prepare(['call ^getbuf!line#'])
+          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
+          \   'label': '',
+          \   'insertTextFormat': 2,
+          \   'insertText': 'getbufinfo$0'
+          \ }, { args -> s:snippet(args.body) })
+          call s:expect(getline('^', '$')).to_equal(['call getbufinfo'])
+        End
+      End
+
+      Describe plain
+        It should not expand
+          let [l:completed_item, l:request_position] = s:prepare(['call ^getbufl!ine#'])
+          let l:changedtick = b:changedtick
+          let l:buflines = getline('^', '$')
+          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
+          \   'label': '',
+          \   'insertText': 'getbufline'
+          \ }, { args -> s:snippet(args.body) })
+          call s:expect(l:buflines).to_equal(getline('^', '$'))
+          call s:expect(l:changedtick).to_equal(b:changedtick)
+        End
+
+        It should expand
+          let [l:completed_item, l:request_position] = s:prepare(['call ^getbuf!line#'])
+          call s:CompletionItem.confirm(l:completed_item, l:request_position, {
+          \   'label': '',
+          \   'insertText': 'getbufinfo'
+          \ }, { args -> s:snippet(args.body) })
+          call s:expect(getline('^', '$')).to_equal(['call getbufinfo'])
+        End
+      End
+
+    End
+
+    Describe realworld
+
+      It rust-analyzer 1
+        let [l:completed_item, l:request_position] = s:prepare([
+        \   'fn main() {',
+        \   '    "aiueo"',
+        \   '        .^box!#',
+        \   '}',
+        \ ])
+        call s:CompletionItem.confirm(l:completed_item, l:request_position, {
+        \   'label': 'box',
+        \   'insertTextFormat': 2,
+        \   'additionalTextEdits': [{'range': {'end': {'character': 9, 'line': 2}, 'start': {'character': 4, 'line': 1}}, 'newText': ''}],
+        \   'textEdit': {'range': {'end': {'character': 12, 'line': 2}, 'start': {'character': 9, 'line': 2}}, 'newText': 'Box::new("aiueo")'},
+        \ }, { args -> s:snippet(args.body) })
+        call s:expect(getline('^', '$')).to_equal([
+        \   'fn main() {',
+        \   '    Box::new("aiueo")',
+        \   '}'
+        \ ])
+      End
+
+      It rust-analyzer 2
+        let [l:completed_item, l:request_position] = s:prepare([
+        \   'fn main() {',
+        \   '    ^PathBuf!#',
+        \   '}',
+        \ ])
+        call s:CompletionItem.confirm(l:completed_item, l:request_position, {
+        \   'label': 'std::path::PathBuf',
+        \   'textEdit': {'range': {'end': {'character': 11, 'line': 1}, 'start': {'character': 4, 'line': 1}}, 'newText': 'PathBuf'},
+        \   'additionalTextEdits': [{'range': {'end': {'character': 0, 'line': 0}, 'start': {'character': 0, 'line': 0}}, 'newText': 'use std::path::PathBuf;'}, {'range': {'end': {'character': 0, 'line': 0}, 'start': {'character': 0, 'line': 0}}, 'newText': "\n\n"}],
+        \   'insertTextFormat': 1,
+        \ }, { args -> s:snippet(args.body) })
+        call s:expect(getline('^', '$')).to_equal([
+        \   'use std::path::PathBuf;',
+        \   '',
+        \   'fn main() {',
+        \   '    PathBuf',
+        \   '}'
+        \ ])
+      End
+
+      It vscode-html-language-server 1
+        let [l:completed_item, l:request_position] = s:prepare([
+        \   '<html>',
+        \   '  <div>',
+        \   '    </^!#>',
+        \   '</html>',
+        \ ])
+        call s:CompletionItem.confirm(l:completed_item, l:request_position, {
+        \   'label': '/div',
+        \   'textEdit': {'range': {'end': {'character': 6, 'line': 2}, 'start': {'character': 0, 'line': 2}}, 'newText': '  </div'},
+        \   'insertTextFormat': 1
+        \ }, { args -> s:snippet(args.body) })
+        call s:expect(getline('^', '$')).to_equal([
+        \   '<html>',
+        \   '  <div>',
+        \   '  </div>',
+        \   '</html>',
+        \ ])
+      End
+
+    End
+
+  End
+
+End
+
+function! s:prepare(lines) abort
+  call setline(1, a:lines)
+  for l:i in range(0, len(a:lines) - 1)
+    let l:lnum = l:i + 1
+    let l:line = a:lines[l:i]
+    if stridx(l:line, '^') >= 0 && stridx(l:line, '!') >= 0 && stridx(l:line, '#') >= 0
+      let l:parts = split(l:line, '\^\|!\|#')
+      let l:request_position = { 'line': l:lnum - 1, 'character': strchars(join(l:parts[0 : 1], '')) }
+      let l:current_position = { 'line': l:lnum - 1, 'character': strchars(join(l:parts[0 : 2], '')) }
+      let l:word = join(l:parts[1 : 2], '')
+      call setline(l:i + 1, join(l:parts, ''))
+      call cursor(s:Position.lsp_to_vim('%', l:current_position))
+      return [{ 'word': l:word }, l:request_position]
+    endif
+  endfor
+  throw 'the target line can''t detected'
+endfunction
+
+function! s:text_edit(start, end, text) abort
+  return {
+  \   'range': {
+  \     'start': s:Position.vim_to_lsp('%', a:start),
+  \     'end': s:Position.vim_to_lsp('%', a:end),
+  \   },
+  \   'newText': a:text
+  \ }
+endfunction
+
+function! s:snippet(text) abort
+  let l:cursor = s:Position.cursor()
+  let l:text = substitute(a:text, '\$\d\+', '', 'g')
+  call s:TextEdit.apply('%', [{
+  \   'range': {
+  \     'start': l:cursor,
+  \     'end': l:cursor,
+  \   },
+  \   'newText': l:text
+  \ }])
+  let l:lines = s:Text.split_by_eol(l:text)
+  let l:cursor = copy(l:cursor)
+  let l:cursor.line += len(l:lines) - 1
+  let l:cursor.character = len(l:lines) == 1 ? l:cursor.character + strchars(l:lines[-1]) : strchars(l:lines[-1])
+  call cursor(s:Position.lsp_to_vim('%', l:cursor))
+endfunction


### PR DESCRIPTION
This PR aims to separate LSP.CompletionItem expansion implementation.

I'm tired to maintain duplicated same implementations.

Benefits.

1. Easy to tests
- Integration test is difficult in this domain.

2. Easy to explain
- For example, completion-nvim can be contain this implementation but this implementation is hard to explain.