### PR TITLE
Properly handle plaintext MarkupContent

### DIFF
--- a/autoload/vital/__vital__/VS/LSP/MarkupContent.vim
+++ b/autoload/vital/__vital__/VS/LSP/MarkupContent.vim
@@ -28,8 +28,6 @@ function! s:normalize(markup_content, ...) abort
     let l:normalized = a:markup_content.value
     if has_key(a:markup_content, 'language')
       let l:normalized = '```' . a:markup_content.language . ' ' . l:normalized . ' ```'
-    elseif get(a:markup_content, 'kind', 'plaintext') ==# 'plaintext'
-      let l:string = '```plaintext ' . l:string . ' ```'
     endif
   endif
   if l:option.compact


### PR DESCRIPTION
A previous commit (cef9f9e) neglected to rename `l:string` to `l:normalized` in the plaintext path.

Additionally, there is no 'plaintext.vim' syntax file, so just assign the value directly (not treating it as language, i.e. not wrapped in triple-backticks).