### PR TITLE
Add more friendly message if syntax file failed to apply

### DIFF
--- a/autoload/vital/__vital__/VS/Vim/Syntax/Markdown.vim
+++ b/autoload/vital/__vital__/VS/Vim/Syntax/Markdown.vim
@@ -54,7 +54,11 @@ function! s:apply(...) abort
 
       let l:filetype_group = substitute(toupper(l:filetype), '\.', '_', 'g')
       if !has_key(b:___VS_Vim_Syntax_Markdown.filetypes, l:filetype_group)
-        call s:_execute('syntax include @%s syntax/%s.vim', l:filetype_group, l:filetype)
+        try
+          call s:_execute('syntax include @%s syntax/%s.vim', l:filetype_group, l:filetype)
+        catch
+          unsilent echomsg printf('Fail to apply "syntax/%s.vim". Add "syntax/%s.vim" to runtimepath for suppress message', l:filetype, l:filetype)
+        endtry
         let b:___VS_Vim_Syntax_Markdown.filetypes[l:filetype_group] = v:true
       endif
 

--- a/autoload/vital/__vital__/VS/Vim/Syntax/Markdown.vim
+++ b/autoload/vital/__vital__/VS/Vim/Syntax/Markdown.vim
@@ -54,11 +54,7 @@ function! s:apply(...) abort
 
       let l:filetype_group = substitute(toupper(l:filetype), '\.', '_', 'g')
       if !has_key(b:___VS_Vim_Syntax_Markdown.filetypes, l:filetype_group)
-        try
-          call s:_execute('syntax include @%s syntax/%s.vim', l:filetype_group, l:filetype)
-        catch
-          unsilent echomsg printf('Fail to apply "syntax/%s.vim". Add "syntax/%s.vim" to runtimepath for suppress message', l:filetype, l:filetype)
-        endtry
+        call s:_execute('syntax include @%s syntax/%s.vim', l:filetype_group, l:filetype)
         let b:___VS_Vim_Syntax_Markdown.filetypes[l:filetype_group] = v:true
       endif
 
@@ -69,7 +65,7 @@ function! s:apply(...) abort
       \   l:filetype_group
       \ )
     catch /.*/
-      unsilent echomsg string({ 'exception': v:exception, 'throwpoint': v:throwpoint })
+      unsilent echomsg printf('Fail to apply "syntax/%s.vim". Add "let g:markdown_fenced_languages = ["%s=$FILETYPE"]" to enable syntax', l:filetype, l:filetype)
     endtry
   endfor
 endfunction


### PR DESCRIPTION
Hi,

When I run `:LspHover`(vim-lsp) using deno lsp, vim-vital-vs show stacktrace.
This is why preview text contains like following markdown syntax.

```
 * ```ts
 * import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
 * ...
 * ```
```

Add `syntax/ts.vim` to `~/.vim/syntax/ts.vim` can apply syntax and avoid show this message.
But showing stacktrace is hard to understand why this message was showed.
So, add little bit more friendly message to what user may do.

Before

https://user-images.githubusercontent.com/56591/144712947-2194fc91-39aa-4141-b2b1-76d0d3ab0dac.mp4

After

https://user-images.githubusercontent.com/56591/144712961-829e3aab-ac20-44dd-8e7f-7040a912cbc4.mp4

Please review this 🙏 

P.S.
Thank you for great works!

