### PR TITLE
VS.Vim.Buffer: Fix E11 error

### DIFF
--- a/autoload/vital/__vital__/VS/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/VS/Vim/Buffer.vim
@@ -42,10 +42,24 @@ function! s:ensure(expr) abort
     if type(a:expr) == type(0)
       throw printf('VS.Vim.Buffer: `%s` is not valid expr.', a:expr)
     endif
-    badd `=a:expr`
+    call s:add(a:expr)
   endif
   return bufnr(a:expr)
 endfunction
+
+"
+" add
+"
+if exists('*bufadd')
+  function! s:add(name) abort
+    let l:bufnr = bufadd(a:name)
+    call setbufvar(l:bufnr, '&buflisted', 1)
+  endfunction
+else
+  function! s:add(name) abort
+    badd `=a:name`
+  endfunction
+endif
 
 "
 " load

--- a/autoload/vital/__vital__/VS/Vim/Buffer.vimspec
+++ b/autoload/vital/__vital__/VS/Vim/Buffer.vimspec
@@ -2,6 +2,7 @@
 " test
 "
 let s:expect = themis#helper('expect')
+let s:assert = themis#helper('assert')
 let s:Buffer = vital#vital#import('VS.Vim.Buffer')
 
 let s:filepath = globpath(&runtimepath, 'autoload/vital/__vital__/VS/Vim/Buffer.vimspec')
@@ -49,6 +50,47 @@ Describe vital#__vital__#VS#Vim#Buffer
       call s:expect(bufexists(l:bufname)).to_equal(0)
       call s:Buffer.ensure(l:bufname)
       call s:expect(bufexists(l:bufname)).to_equal(1)
+    End
+
+  End
+
+  Describe #add
+
+    It should add buffer
+      let l:bufname1 = 'VS_Vim_Buffer_badd:test1'
+      call s:expect(bufexists(l:bufname1)).to_equal(0)
+      call s:Buffer.add(l:bufname1)
+      call s:expect(bufexists(l:bufname1)).to_equal(1)
+
+      if exists('*bufadd')
+        let l:bufname2 = 'VS_Vim_Buffer_badd:test2'
+        badd `=l:bufname2`
+        let l:buf1info = filter(getbufinfo(l:bufname1)[0], 'v:key !~# "name\\|bufnr"')
+        let l:buf2info = filter(getbufinfo(l:bufname2)[0], 'v:key !~# "name\\|bufnr"')
+        call s:expect(l:buf1info).to_equal(l:buf2info)
+      endif
+    End
+
+    It does not raise E11 error even in cmdwin (when bufadd() exists)
+      if !exists('*bufadd')
+        call s:assert.skip('Missing bufadd()')
+      endif
+      function TestInCmdwin() abort
+        call s:expect(getcmdwintype()).not.to_equal('')
+        try
+          call s:Buffer.add('VS_Vim_Buffer_badd:test_no_throw')
+        catch /^Vim\%((\a\+)\)\=:E11:/
+          call s:assert.fail('E11 error raised.')
+        endtry
+        return ''
+      endfunction
+      nnoremap <expr> @ TestInCmdwin()
+      try
+        execute "normal q:@:q\<CR>"
+      finally
+        nunmap @
+        delfunction TestInCmdwin
+      endtry
     End
 
   End

--- a/autoload/vital/__vital__/VS/Vim/Buffer.vimspec
+++ b/autoload/vital/__vital__/VS/Vim/Buffer.vimspec
@@ -65,8 +65,11 @@ Describe vital#__vital__#VS#Vim#Buffer
       if exists('*bufadd')
         let l:bufname2 = 'VS_Vim_Buffer_badd:test2'
         badd `=l:bufname2`
-        let l:buf1info = filter(getbufinfo(l:bufname1)[0], 'v:key !~# "name\\|bufnr"')
-        let l:buf2info = filter(getbufinfo(l:bufname2)[0], 'v:key !~# "name\\|bufnr"')
+        " The 'lnum' is 1 for a buffer added by ':badd' before patch 8.2.1902
+        " while it is 0 for a buffer added by 'bufadd()' or ':badd' after the
+        " patch.  Skip the checks for 'lnum' entry.
+        let l:buf1info = filter(getbufinfo(l:bufname1)[0], 'v:key !~# "name\\|bufnr\\|lnum"')
+        let l:buf2info = filter(getbufinfo(l:bufname2)[0], 'v:key !~# "name\\|bufnr\\|lnum"')
         call s:expect(l:buf1info).to_equal(l:buf2info)
       endif
     End
@@ -86,7 +89,7 @@ Describe vital#__vital__#VS#Vim#Buffer
       endfunction
       nnoremap <expr> @ TestInCmdwin()
       try
-        execute "normal q:@:q\<CR>"
+        execute "normal q:@\<C-w>q"
       finally
         nunmap @
         delfunction TestInCmdwin


### PR DESCRIPTION
E11 error is raised when ensure() is called in cmdwin because `:badd` command isn't available in cmdwin.

### How to reproduce
`vim -u NONE -N -S /path/to/following/script.vim`
```vim
if !isdirectory('/tmp/vital-vs')
  !git clone --depth=1 https://github.com/hrsh7th/vim-vital-vs /tmp/vital-vs
endif

source /tmp/vital-vs/autoload/vital/__vital__/VS/Vim/Buffer.vim
let g:Ensure = function(printf("\<SNR>%d_ensure",
      \ matchstr(execute('filter Buffer.vim scriptnames'), '\d\+')))

try
  execute "normal! q:\<Cmd>call call(g:Ensure, ['test-vital-vs://newbuf'])\<CR>"
catch
  echomsg v:throwpoint
  echomsg v:exception
endtry
```

output:
```
command line..script /Users/mityu/baddrepro.vim[11]..function <SNR>2_ensure, line 5
Vim(badd):E11: Invalid in command-line window; <CR> executes, CTRL-C quits
```

### Solution
Prefer using `bufadd()` function to `:badd` command.


### Additional context
```vim
function! TestBadd()
  let buf1 = bufadd('newbuf1')
  call setbufvar(buf1, '&buflisted', 1)

  badd newbuf2
  let buf2 = bufnr('newbuf2')

  let buf1info = getbufinfo(buf1)[0]
  let buf2info = getbufinfo(buf2)[0]

  let diffs = []
  for [k, v1] in items(buf1info)
    let v2 = buf2info[k]
    if v1 != v2
      call add(diffs, printf('%s: (%s, %s)', k, v1, v2))
    endif
  endfor

  let msg = "Diffs:\n"
  for d in diffs
    let msg .= '  ' . d . "\n"
  endfor
  return msg
endfunction
echomsg TestBadd()
" Diffs:
"  bufnr: (2, 3)
"  name: (/Users/mityu/newbuf1, /Users/mityu/newbuf2)
```

As the script above, it seems that this script
```vim
let bufnr = bufadd(bufname)
call setbufvar(bufnr, '&buflisted', 1)
```
can alternate `:badd` command, but I'm not sure this is actually right.
Please tell me if there're some problems.