### PR TITLE
Fix CI on neovim nightly on Windows/macOS

### DIFF
--- a/.github/workflows/mac_neovim.yml
+++ b/.github/workflows/mac_neovim.yml
@@ -43,6 +43,7 @@ jobs:
         shell: bash
         run: |
           export PATH=~/nvim-osx64/bin:$PATH
+          export PATH=~/nvim-macos/bin:$PATH
           export PATH=~/langservers:$PATH
           export PATH=~/themis/bin:$PATH
           export THEMIS_VIM=nvim

--- a/.github/workflows/windows_neovim.yml
+++ b/.github/workflows/windows_neovim.yml
@@ -45,6 +45,7 @@ jobs:
         shell: cmd
         run: |
           SET PATH=%USERPROFILE%\Neovim\bin;%PATH%;
+          SET PATH=%USERPROFILE%\nvim-win64\bin;%PATH%;
           SET PATH=%USERPROFILE%\themis\bin;%PATH%;
           SET THEMIS_VIM=nvim
           nvim --version


### PR DESCRIPTION
It seems that the name of directories created when extracting archives have changed.  This PR adds them to PATH in order to shell can find the Neovim binary properly.
```
curl -L -O https://github.com/neovim/neovim/releases/download/nightly/nvim-macos.tar.gz
tar xzf ./nvim-macos.tar.gz  # => Created directory: ./nvim-macos
curl -L -O https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip
unzip ./nvim-win64.zip  # => Crated directory: ./nvim-win64
```